### PR TITLE
🚀 Add Custom Permissions Dialog and Fixed the condition when the user already reject or decline the request permission dialog two or three times (which is the default logic is app won't show the dialog again, so I change it, if the user already reject it 3 times, the app will show dialog, when user click open it will open the settings for the MentalQ App):

### DIFF
--- a/.idea/appInsightsSettings.xml
+++ b/.idea/appInsightsSettings.xml
@@ -10,9 +10,9 @@
               <option name="connection">
                 <ConnectionSetting>
                   <option name="appId" value="com.c242_ps246.mentalq" />
-                  <option name="mobileSdkAppId" value="1:1056734232546:android:5af85f8a4f7e61394803bb" />
-                  <option name="projectId" value="mentalq-app" />
-                  <option name="projectNumber" value="1056734232546" />
+                  <option name="mobileSdkAppId" value="1:130948402050:android:2c33f3d0475709ce745d9b" />
+                  <option name="projectId" value="mentalq-cloud" />
+                  <option name="projectNumber" value="130948402050" />
                 </ConnectionSetting>
               </option>
               <option name="signal" value="SIGNAL_UNSPECIFIED" />

--- a/app/src/main/java/com/c242_ps246/mentalq/ui/component/CustomDialog.kt
+++ b/app/src/main/java/com/c242_ps246/mentalq/ui/component/CustomDialog.kt
@@ -21,7 +21,9 @@ fun CustomDialog(
     dialogTitle: String,
     dialogMessage: String,
     onConfirm: () -> Unit,
+    confirmButtonText: String = stringResource(id = R.string.ok),
     onDismiss: () -> Unit,
+    dismissButtonText: String = stringResource(id = R.string.cancel),
     showCancelButton: Boolean = true
 ) {
     Dialog(onDismissRequest = onDismiss) {
@@ -67,7 +69,7 @@ fun CustomDialog(
                             onClick = onDismiss,
                             modifier = Modifier.weight(1f)
                         ) {
-                            Text(stringResource(id = R.string.cancel))
+                            Text(dismissButtonText)
                         }
                     }
 
@@ -78,7 +80,7 @@ fun CustomDialog(
                             containerColor = MaterialTheme.colorScheme.primary
                         )
                     ) {
-                        Text(stringResource(id = R.string.ok))
+                        Text(confirmButtonText)
                     }
                 }
             }

--- a/app/src/main/res/values-in/strings.xml
+++ b/app/src/main/res/values-in/strings.xml
@@ -151,4 +151,12 @@
 
     <string name="offline_title">Tidak Ada Koneksi Internet</string>
     <string name="offline_message">Anda sedang offline. Beberapa fitur mungkin tidak tersedia.</string>
+
+    <string name="permission_required">Izin Diperlukan</string>
+    <string name="audio_permission_rationale">Izin merekam audio diperlukan agar fitur ini dapat berfungsi dengan baik. Harap berikan izin yang diminta.</string>
+    <string name="audio_permission_settings">MentalQ membutuhkan akses mikrofon untuk mengubah suara Anda menjadi teks. Harap berikan izin di pengaturan.</string>
+    <string name="notification_permission_rationale">Izin notifikasi diperlukan agar fitur ini dapat berfungsi dengan baik. Harap berikan izin yang diminta.</string>
+    <string name="notification_permission_settings">MentalQ membutuhkan akses notifikasi untuk mengirimkan pengingat kepada Anda. Harap berikan izin di pengaturan.</string>
+    <string name="try_again">Coba Lagi</string>
+    <string name="open_settings">Buka</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -151,4 +151,12 @@
 
     <string name="offline_title">No Internet Connection</string>
     <string name="offline_message">You are currently offline. Some features may not be available.</string>
+
+    <string name="permission_required">Permission Required</string>
+    <string name="audio_permission_rationale">Audio recording permission is needed for this feature to work properly. Please grant the permission request.</string>
+    <string name="audio_permission_settings">MentalQ needs microphone access to convert your voice to text. Please grant permission in settings.</string>
+    <string name="notification_permission_rationale">Notification permission is needed for this feature to work properly. Please grant the permission request.</string>
+    <string name="notification_permission_settings">MentalQ needs notification access to send you reminder notifications. Please grant permission in settings.</string>
+    <string name="try_again">Try Again</string>
+    <string name="open_settings">Open</string>
 </resources>


### PR DESCRIPTION
🚀 Add Custom Permissions Dialog and Fixed the condition when the user already reject or decline the request permission dialog two or three times (which is the default logic is app won't show the dialog again, so I change it, if the user already reject it 3 times, the app will show dialog, when user click open it will open the settings for the MentalQ App):

* strings.xml: `[📝](app/src/main/res/values-in/strings.xml): Add permission related strings`
* DetailNoteScreen.kt: `[🔧](app/src/main/java/com/c242_ps246/mentalq/ui/main/note/detail/DetailNoteScreen.kt): Implement permission handling`
* CustomDialog.kt: `[📝](app/src/main/java/com/c242_ps246/mentalq/ui/component/CustomDialog.kt): Add confirm and dismiss button text properties`
* strings.xml: `[📝](app/src/main/res/values/strings.xml): Add permission related strings`

This commit adds permission related strings for audio recording and notification, and implements permission handling in DetailNoteScreen.kt using a CustomDialog component. Additionally, the CustomDialog component is modified to accept confirm and dismiss button text properties.