### PR TITLE
🔧 Refactor(DetailNoteScreen.kt): Remove onBackClick call in BackHandler

### DIFF
--- a/app/src/main/java/com/c242_ps246/mentalq/ui/main/note/detail/DetailNoteScreen.kt
+++ b/app/src/main/java/com/c242_ps246/mentalq/ui/main/note/detail/DetailNoteScreen.kt
@@ -78,7 +78,6 @@ fun DetailNoteScreen(
 
     BackHandler {
         handleBack()
-        onBackClick()
     }
 
     LaunchedEffect(noteId) {


### PR DESCRIPTION
This commit removes the call to 'onBackClick()' function inside the BackHandler in DetailNoteScreen.kt file.